### PR TITLE
Close each file after it's written.

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -117,7 +117,7 @@ func generateFieldMap(fileName string, printOnConsole bool) {
 			fmt.Printf("Error opening file %v", err)
 			panic(err)
 		}
-		defer writer.Close()
 		writer.WriteString(string(finalContent))
+		writer.Close()
 	}
 }


### PR DESCRIPTION
I found on the mac that when you use this tool with a large number of structs, you'll hit the OS limit on number of open files by a single process. This is because the deferred method won't be invoked until the conclusion of the loops. I believe it would be more efficient (and it fixed my issue) to close each file after it's been written.
